### PR TITLE
Modifies package.json to valid format so Autodesk registry would generate metadata.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
   "name": "@buildingconnected/google-places",
   "description": "node.js client for google places API",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "homepage": "http://github.com/jpowers/node-google-places",
   "author": "Jay Powers <jay@vermonster.com>",
-  "contributors": ["Marcin Wiśniowski <shfx@shfx.pl> (http://shfx.pl)"],
-  "scripts":{"test":"node ./test/index.test.js"},
+  "contributors": [
+    "Marcin Wiśniowski <shfx@shfx.pl> (http://shfx.pl)"
+  ],
+  "scripts": {
+    "test": "node ./test/index.test.js"
+  },
   "repository": {
     "type": "git",
     "url": "http://github.com/jpowers/node-google-places.git"
@@ -14,10 +18,9 @@
     "underscore": "1.8.3",
     "url": "0.11.0"
   },
-  "devDependencies": [
-    "vows",
-    "node-fakeweb"
-  ],
+  "devDependencies": {
+    "vows": "0.8.3",
+    "node-fakeweb": "1.1.0"
+  },
   "main": "./lib/google-places.js"
 }
-


### PR DESCRIPTION
The `devDependencies` in the package.json was an array which the Autodesk
npm registry does not like. It would fail to parse the metadata of the package
which meant it could not be detected for installation. Changing it to the
expected object with version numbers fixes the issue on Autodesk's registry.

Updated the version to 0.0.4